### PR TITLE
add some features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ The package is tested on Ubuntu 14.04 with ROS indigo.
 Note that the official SDK is modified within this package due to some bugs or unsupported features. Please carefully update the SDK, since the new SDK may not work with the provided software.
 
 ## License
+
 * The license for the official SDK is the MIT license which is included in the `include/imu_vn_100/vncpplib`
 * The license for the other codes is Apache 2.0 whenever not specified.
 
 ## Compiling
+
 This is a Catkin package. Make sure the package is on `ROS_PACKAGE_PATH` after cloning the package to your workspace. And the normal procedure for compiling a catkin package will work.
 
 ```
@@ -46,6 +48,7 @@ The rate of the IMU data.
 enable_magn  (bool, default: true)
 enable_press (bool, default: true)
 enable_temp  (bool, default: true)
+enable_rpy  (bool, default: false)
 ```
 
 Enable other possible messages that the driver is available to send. Note that the frequency of the data for each of these messages will be the same with the IMU data, if the topic is enabled.
@@ -54,15 +57,60 @@ Enable other possible messages that the driver is available to send. Note that t
 
 The rate of the sync out trigger signal. Note that the actual rate may not exactly match the provided rate, unless the provided rate is a divisor of 800. When `sync_rate` <= 0, it is disabled.
 
+`binary_output` (`boolean`, `default: true`)
+
+Use binary  protocol for receiving messages instead of ASCII. 
+
+`binary_async_mode` (`int`, `default: 2`)
+
+Set serial port for binary messages to one of:
+
+* `1` - Serial port 1
+* `2` - Serial port 2
+
+`imu_compensated` (`boolean`, `default: true`)
+
+Use *compensated* IMU measurements (i.e. angular velocity, linear acceleration, magnetic field).
+
+`tf_ned_to_enu` (`boolean`, `default: false`)
+
+Convert (e.g. `geometry_msg/Vector3`) from NED (native) to ENU coordinate frame.
+
+`vpe_enable` (`boolean`, `default: true`)
+
+Use Vector Processing Engine.
+
+`vpe_heading_mode` (`int`, `default: 1`)
+
+Set VPE heading mode to one of:
+
+* `0` - Absolute
+* `1` - Relative
+* `2` - Indoor
+
+`vpe_filtering_mode` (`int`, `default: 1`)
+
+Set VPE filtering mode to one of:
+
+* `0` - Off
+* `1` - *MODE 1*
+
+`vpe_tuning_mode` (`int`, `default: 1`)
+
+Set VPE tuning mode to one of:
+
+* `0` - Off
+* `1` - *MODE 1*
+
 **Published Topics**
 
 `imu/imu` (`sensor_msgs/Imu`)
 
-The message contains the uncompensated (for the definition of UNCOMPENSATED, please refer to the [user manual](http://www.vectornav.com/docs/default-source/documentation/vn-100-documentation/UM001.pdf?sfvrsn=10)) angular velocity and linear acceleration. Note that the orientation is not provided on this topic.
+If `imu_compensated` is `false`, the default, then the message contains the *uncompensated* (for the definition of UNCOMPENSATED, please refer to the [user manual](http://www.vectornav.com/docs/default-source/documentation/vn-100-documentation/UM001.pdf?sfvrsn=10)) angular velocity and linear acceleration. Otherwise both are *compensated*.
 
 `imu/magnetic_field` (`sensor_msgs/MagneticField`)
 
-Uncompensated magnetic field.
+Magnetic field. If `imu_compensated` is `false` then it is *uncompensated* otherwise it is *compensated*.
 
 `imu/pressure` (`sensor_msgs/FluidPressure`)
 
@@ -71,6 +119,10 @@ Pressure.
 `imu/temperature` (`sensor_msgs/Temperature`)
 
 Temperature in degree Celsius
+
+`imu/rpy` (`geometry_msgs/Vector3Stamped`)
+
+Estimated *attitute* roll (`x`), pitch (`y`) and yaw (`z`) angles measured in radians in body frame. These are with respect to NED or ENU coordinate frame depending on`tf_ned_to_enu`.
 
 **Node**
 
@@ -81,6 +133,7 @@ roslaunch imu_vn_100 vn_100_cont.launch
 ```
 
 ## FAQ
+
 1. The driver can't open my device?
 Make sure you have ownership of the device in `/dev`.
 

--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -117,12 +117,24 @@ class ImuVn100 {
   bool enable_mag_ = true;
   bool enable_pres_ = true;
   bool enable_temp_ = true;
+  bool enable_rpy_ = false;
+
   bool binary_output_ = true;
+  int binary_async_mode_ = BINARY_ASYNC_MODE_SERIAL_2;
+
+  bool imu_compensated_ = false;
+
+  bool tf_ned_to_enu_ = false;
+
+  bool vpe_enable_ = true;
+  int vpe_heading_mode_ = 1;
+  int vpe_filtering_mode_ = 1;
+  int vpe_tuning_mode_ = 1;
 
   SyncInfo sync_info_;
 
   du::Updater updater_;
-  DiagnosedPublisher pd_imu_, pd_mag_, pd_pres_, pd_temp_;
+  DiagnosedPublisher pd_imu_, pd_mag_, pd_pres_, pd_temp_, pd_rpy_;
 
   void FixImuRate();
   void LoadParameters();

--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -130,6 +130,12 @@ class ImuVn100 {
   int vpe_heading_mode_ = 1;
   int vpe_filtering_mode_ = 1;
   int vpe_tuning_mode_ = 1;
+  VnVector3 vpe_mag_base_tuning_;
+  VnVector3 vpe_mag_adaptive_tuning_;
+  VnVector3 vpe_mag_adaptive_filtering_;
+  VnVector3 vpe_accel_base_tuning_;
+  VnVector3 vpe_accel_adaptive_tuning_;
+  VnVector3 vpe_accel_adaptive_filtering_;
 
   SyncInfo sync_info_;
 

--- a/launch/vn_100_cont.launch
+++ b/launch/vn_100_cont.launch
@@ -12,12 +12,24 @@
     <arg name="sync_rate" default="20"/>
     <arg name="sync_pulse_width_us" default="1000"/>
 
+    <!-- Binary settings -->
     <arg name="binary_output" default="true"/>
+    <arg name="binary_async_mode" default="2"/>
+    
+    <arg name="tf_ned_to_enu" default="false"/>
+    <arg name="imu_compensated" default="false"/>
 
+    <!-- VPE settings -->
+    <arg name="vpe_enable" default="true"/>
+    <arg name="vpe_heading_mode" default="1"/>
+    <arg name="vpe_filtering_mode" default="1"/>
+    <arg name="vpe_tuning_mode" default="1"/>
+    
     <!-- Ros Topic settings -->
     <arg name="enable_mag" default="true"/>
     <arg name="enable_pres" default="true"/>
     <arg name="enable_temp" default="true"/>
+    <arg name="enable_rpy" default="false"/>
 
     <node pkg="imu_vn_100" name="$(arg imu)" type="imu_vn_100_cont_node" output="$(arg output)">
         <param name="port" type="string" value="$(arg port)"/>
@@ -25,10 +37,18 @@
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
         <param name="imu_rate" type="int" value="$(arg imu_rate)"/>
         <param name="binary_output" type="bool" value="$(arg binary_output)"/>
+        <param name="binary_async_mode" type="int" value="$(arg binary_async_mode)"/>
+        <param name="tf_ned_to_enu" type="bool" value="$(arg tf_ned_to_enu)"/>
+        <param name="imu_compensated" type="bool" value="$(arg imu_compensated)"/>
         <param name="enable_mag" type="bool" value="$(arg enable_mag)"/>
         <param name="enable_pres" type="bool" value="$(arg enable_pres)"/>
         <param name="enable_temp" type="bool" value="$(arg enable_temp)"/>
+        <param name="enable_rpy" type="bool" value="$(arg enable_rpy)"/>
         <param name="sync_rate" type="int" value="$(arg sync_rate)"/>
         <param name="sync_pulse_width_us" type="int" value="$(arg sync_pulse_width_us)"/>
+        <param name="vpe_enable" type="bool" value="$(arg vpe_enable)"/>
+        <param name="vpe_heading_mode" type="int" value="$(arg vpe_heading_mode)"/>
+        <param name="vpe_filtering_mode" type="int" value="$(arg vpe_filtering_mode)"/>
+        <param name="vpe_tuning_mode" type="int" value="$(arg vpe_tuning_mode)"/>
     </node>
 </launch>

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -369,31 +369,44 @@ void ImuVn100::Stream(bool async) {
       }
       if (!sgrp1.empty()) {
         std::stringstream ss;
-        std::copy(sgrp1.begin(), sgrp1.end(),
-                  std::ostream_iterator<std::string>(ss, "|"));
+        std::copy(
+          sgrp1.begin(),
+          sgrp1.end(),
+          std::ostream_iterator<std::string>(ss, "|")
+        );
         std::string s = ss.str();
         s.pop_back();
         ROS_INFO("Streaming #1: %s", s.c_str());
       }
       if (!sgrp3.empty()) {
         std::stringstream ss;
-        std::copy(sgrp3.begin(), sgrp3.end(),
-                  std::ostream_iterator<std::string>(ss, "|"));
+        std::copy(
+          sgrp3.begin(),
+          sgrp3.end(),
+          std::ostream_iterator<std::string>(ss, "|")
+        );
         std::string s = ss.str();
         s.pop_back();
         ROS_INFO("Streaming #3: %s", s.c_str());
       }
       if (!sgrp5.empty()) {
         std::stringstream ss;
-        std::copy(sgrp5.begin(), sgrp5.end(),
-                  std::ostream_iterator<std::string>(ss, "|"));
+        std::copy(
+          sgrp5.begin(),
+          sgrp5.end(),
+          std::ostream_iterator<std::string>(ss, "|")
+        );
         std::string s = ss.str();
         s.pop_back();
         ROS_INFO("Streaming #5: %s", s.c_str());
       }
       VnEnsure(vn100_setBinaryOutput1Configuration(
-        &imu_, binary_async_mode_, kBaseImuRate / imu_rate_, grp1, grp3, grp5,
-        true));
+        &imu_,
+        binary_async_mode_,
+        kBaseImuRate / imu_rate_,
+        grp1, grp3, grp5,
+        true
+      ));
     } else {
       // Set the ASCII output data type and data rate
       // ROS_INFO("Configure the output data type and frequency (id: 6 & 7)");
@@ -545,7 +558,6 @@ void RosQuaternionFromVnQuaternion(geometry_msgs::Quaternion& ros_quat,
 
 geometry_msgs::Vector3 WorldNEDtoENU(const geometry_msgs::Vector3& ned) {
   // (x y z) -> (y  x -z)
-  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L217
   geometry_msgs::Vector3 enu;
   enu.x = ned.y;
   enu.y = ned.x;
@@ -554,35 +566,32 @@ geometry_msgs::Vector3 WorldNEDtoENU(const geometry_msgs::Vector3& ned) {
 }
 
 geometry_msgs::Quaternion WorldNEDtoENU(const geometry_msgs::Quaternion& ned) {
-  // (w x y z)->(y  x -z w)
-  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L217
+  // (x y z w)->(y  x -z w)
   geometry_msgs::Quaternion enu;
-  enu.w = ned.y;
-  enu.x = ned.x;
-  enu.y = -ned.z;
-  enu.z = ned.w;
+  enu.w = ned.w;
+  enu.x = ned.y;
+  enu.y = ned.x;
+  enu.z = -ned.z;
   return enu;
 }
 
 geometry_msgs::Vector3 BodyFixedNEDtoENU(const geometry_msgs::Vector3 ned) {
   // (x y z)->(x -y -z)
-  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L216
   geometry_msgs::Vector3 enu;
   enu.x = ned.x;
-  enu.y -ned.y;
+  enu.y = -ned.y;
   enu.z = -ned.z;
   return enu;
 }
 
 geometry_msgs::Quaternion BodyFixedNEDtoENU(
   const geometry_msgs::Quaternion& ned) {
-  // (w x y z)->(x -y -z w)
-  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L217
+  // (x y z w)->(x -y -z w)
   geometry_msgs::Quaternion enu;
-  enu.w = ned.x;
-  enu.x = -ned.y;
-  enu.y = -ned.z;
-  enu.z = ned.w;
+  enu.w = ned.w;
+  enu.x = ned.x;
+  enu.y = -ned.y;
+  enu.z = -ned.z;
   return enu;
 }
 

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -16,10 +16,15 @@
 
 #include <imu_vn_100/imu_vn_100.h>
 
+#include <geometry_msgs/Vector3Stamped.h>
+#include <tf/transform_datatypes.h>
+
 namespace imu_vn_100 {
 
 // LESS HACK IS STILL HACK
 ImuVn100* imu_vn_100_ptr;
+
+using geometry_msgs::Vector3Stamped;
 
 using sensor_msgs::Imu;
 using sensor_msgs::MagneticField;
@@ -30,8 +35,10 @@ void RosVector3FromVnVector3(geometry_msgs::Vector3& ros_vec3,
                              const VnVector3& vn_vec3);
 void RosQuaternionFromVnQuaternion(geometry_msgs::Quaternion& ros_quat,
                                    const VnQuaternion& vn_quat);
-void FillImuMessage(sensor_msgs::Imu& imu_msg,
-                    const VnDeviceCompositeData& data, bool binary_output);
+geometry_msgs::Vector3 WorldNEDtoENU(const geometry_msgs::Vector3& ned);
+geometry_msgs::Quaternion WorldNEDtoENU(const geometry_msgs::Quaternion& ned);
+geometry_msgs::Vector3 BodyFixedNEDtoENU(const geometry_msgs::Vector3 ned);
+geometry_msgs::Quaternion BodyFixedNEDtoENU(const geometry_msgs::Quaternion& ned);
 
 void AsyncListener(void* sender, VnDeviceCompositeData* data) {
   imu_vn_100_ptr->PublishData(*data);
@@ -109,11 +116,23 @@ void ImuVn100::LoadParameters() {
   pnh_.param("enable_mag", enable_mag_, true);
   pnh_.param("enable_pres", enable_pres_, true);
   pnh_.param("enable_temp", enable_temp_, true);
+  pnh_.param("enable_rpy", enable_rpy_, false);
 
   pnh_.param("sync_rate", sync_info_.rate, kDefaultSyncOutRate);
   pnh_.param("sync_pulse_width_us", sync_info_.pulse_width_us, 1000);
 
   pnh_.param("binary_output", binary_output_, true);
+  pnh_.param("binary_async_mode", binary_async_mode_,
+             BINARY_ASYNC_MODE_SERIAL_2);
+
+  pnh_.param("tf_ned_to_enu", tf_ned_to_enu_, false);
+
+  pnh_.param("imu_compensated", imu_compensated_, false);
+
+  pnh_.param("vpe_enable", vpe_enable_, true);
+  pnh_.param("vpe_heading_mode", vpe_heading_mode_, 1);
+  pnh_.param("vpe_filtering_mode", vpe_filtering_mode_, 1);
+  pnh_.param("vpe_tuning_mode", vpe_tuning_mode_, 1);
 
   FixImuRate();
   sync_info_.FixSyncRate();
@@ -133,6 +152,9 @@ void ImuVn100::CreateDiagnosedPublishers() {
   if (enable_temp_) {
     pd_temp_.Create<Temperature>(pnh_, "temperature", updater_,
                                  imu_rate_double_);
+  }
+  if (enable_rpy_) {
+      pd_rpy_.Create<Vector3Stamped>(pnh_, "rpy", updater_, imu_rate_double_);
   }
 }
 
@@ -189,12 +211,38 @@ void ImuVn100::Initialize() {
         sync_info_.pulse_width_us * 1000, true));
 
     if (!binary_output_) {
-      ROS_INFO("Set Communication Protocal Control Register (id:30).");
+      ROS_INFO("Set Communication Protocol Control Register (id:30).");
       VnEnsure(vn100_setCommunicationProtocolControl(
-          &imu_, SERIALCOUNT_SYNCOUT_COUNT, SERIALSTATUS_OFF, SPICOUNT_NONE,
-          SPISTATUS_OFF, SERIALCHECKSUM_8BIT, SPICHECKSUM_8BIT, ERRORMODE_SEND,
-          true));
+        &imu_, SERIALCOUNT_SYNCOUT_COUNT, SERIALSTATUS_OFF, SPICOUNT_NONE,
+        SPISTATUS_OFF, SERIALCHECKSUM_8BIT, SPICHECKSUM_8BIT, ERRORMODE_SEND,
+        true));
     }
+  }
+
+  uint8_t vpe_enable;
+  uint8_t vpe_heading_mode;
+  uint8_t vpe_filtering_mode;
+  uint8_t vpe_tuning_mode;
+  VnEnsure(vn100_getVpeControl(&imu_, &vpe_enable, &vpe_heading_mode,
+    &vpe_filtering_mode, &vpe_tuning_mode));
+  ROS_INFO("Default VPE enable: %hu", vpe_enable);
+  ROS_INFO("Default VPE heading mode: %hu", vpe_heading_mode);
+  ROS_INFO("Default VPE filtering mode: %hu", vpe_filtering_mode);
+  ROS_INFO("Default VPE tuning mode: %hu", vpe_tuning_mode);
+  if (vpe_enable != vpe_enable_ ||
+      vpe_heading_mode != vpe_tuning_mode_ ||
+      vpe_filtering_mode != vpe_tuning_mode_ ||
+      vpe_tuning_mode != vpe_tuning_mode_) {
+      vpe_enable = vpe_enable_;
+      vpe_heading_mode = vpe_tuning_mode_;
+      vpe_filtering_mode = vpe_tuning_mode_;
+      vpe_tuning_mode = vpe_tuning_mode_;
+      ROS_INFO("Setting VPE enable: %hu", vpe_enable);
+      ROS_INFO("Setting VPE heading mode: %hu", vpe_heading_mode);
+      ROS_INFO("Setting VPE filtering mode: %hu", vpe_filtering_mode);
+      ROS_INFO("Setting VPE tuning mode: %hu", vpe_tuning_mode);
+      VnEnsure(vn100_setVpeControl(&imu_, vpe_enable, vpe_heading_mode,
+          vpe_filtering_mode, vpe_tuning_mode, true));
   }
 
   CreateDiagnosedPublishers();
@@ -213,11 +261,63 @@ void ImuVn100::Stream(bool async) {
 
     if (binary_output_) {
       // Set the binary output data type and data rate
+      uint16_t grp1 = BG1_QTN | BG1_SYNC_IN_CNT;
+      std::list<std::string> sgrp1 = {"BG1_QTN", "BG1_SYNC_IN_CNT"};
+      uint16_t grp3 = BG3_NONE;
+      std::list<std::string> sgrp3;
+      uint16_t grp5 = BG5_NONE;
+      std::list<std::string> sgrp5;
+      if (imu_compensated_) {
+        grp1 |=  BG1_ACCEL | BG1_ANGULAR_RATE;
+        sgrp1.push_back("BG1_ACCEL");
+        sgrp1.push_back("BG1_ANGULAR_RATE");
+        if (enable_mag_) {
+          grp3 |= BG3_MAG;
+          sgrp3.push_back("BG3_MAG");
+        }
+      } else {
+        grp1 |=  BG1_IMU;
+        sgrp1.push_back("BG1_IMU");
+        if (enable_mag_) {
+          grp3 |= BG3_UNCOMP_MAG;
+          sgrp3.push_back("BG3_UNCOMP_MAG");
+        }
+      }
+      if (enable_temp_) {
+          grp3 |= BG3_TEMP;
+          sgrp3.push_back("BG3_TEMP");
+      }
+      if (enable_pres_) {
+          grp3 |= BG3_PRES;
+          sgrp3.push_back("BG3_PRES");
+      }
+      if (!sgrp1.empty()) {
+        std::stringstream ss;
+        std::copy(sgrp1.begin(), sgrp1.end(),
+                  std::ostream_iterator<std::string>(ss, "|"));
+        std::string s = ss.str();
+        s.pop_back();
+        ROS_INFO("Streaming #1: %s", s.c_str());
+      }
+      if (!sgrp3.empty()) {
+        std::stringstream ss;
+        std::copy(sgrp3.begin(), sgrp3.end(),
+                  std::ostream_iterator<std::string>(ss, "|"));
+        std::string s = ss.str();
+        s.pop_back();
+        ROS_INFO("Streaming #3: %s", s.c_str());
+      }
+      if (!sgrp5.empty()) {
+        std::stringstream ss;
+        std::copy(sgrp5.begin(), sgrp5.end(),
+                  std::ostream_iterator<std::string>(ss, "|"));
+        std::string s = ss.str();
+        s.pop_back();
+        ROS_INFO("Streaming #5: %s", s.c_str());
+      }
       VnEnsure(vn100_setBinaryOutput1Configuration(
-          &imu_, BINARY_ASYNC_MODE_SERIAL_2, kBaseImuRate / imu_rate_,
-          BG1_QTN | BG1_IMU | BG1_MAG_PRES | BG1_SYNC_IN_CNT,
-          // BG1_IMU,
-          BG3_NONE, BG5_NONE, true));
+        &imu_, binary_async_mode_, kBaseImuRate / imu_rate_, grp1, grp3, grp5,
+        true));
     } else {
       // Set the ASCII output data type and data rate
       // ROS_INFO("Configure the output data type and frequency (id: 6 & 7)");
@@ -260,13 +360,48 @@ void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
   imu_msg.header.stamp = ros::Time::now();
   imu_msg.header.frame_id = frame_id_;
 
-  FillImuMessage(imu_msg, data, binary_output_);
+  if (imu_compensated_) {
+    RosVector3FromVnVector3(imu_msg.linear_acceleration, data.acceleration);
+    RosVector3FromVnVector3(imu_msg.angular_velocity, data.angularRate);
+  } else {
+    // NOTE: The IMU angular velocity and linear acceleration outputs are
+    // swapped. And also why are they different?
+    RosVector3FromVnVector3(imu_msg.angular_velocity,
+                            data.accelerationUncompensated);
+    RosVector3FromVnVector3(imu_msg.linear_acceleration,
+                            data.angularRateUncompensated);
+  }
+  if (binary_output_) {
+    RosQuaternionFromVnQuaternion(imu_msg.orientation, data.quaternion);
+  }
+  if  (tf_ned_to_enu_) {
+    imu_msg.orientation = WorldNEDtoENU(imu_msg.orientation);
+    imu_msg.angular_velocity =  BodyFixedNEDtoENU(imu_msg.angular_velocity);
+    imu_msg.linear_acceleration = BodyFixedNEDtoENU(
+      imu_msg.linear_acceleration);
+  }
   pd_imu_.Publish(imu_msg);
+
+  if (enable_rpy_) {
+    tf::Matrix3x3 rot(tf::Quaternion(
+        imu_msg.orientation.x,
+        imu_msg.orientation.y,
+        imu_msg.orientation.z,
+        imu_msg.orientation.w
+    ));
+    geometry_msgs:Vector3Stamped rpy_msg;
+    rpy_msg.header = imu_msg.header;
+    rot.getRPY(rpy_msg.vector.x, rpy_msg.vector.y, rpy_msg.vector.z);
+    pd_rpy_.Publish(rpy_msg);
+  }
 
   if (enable_mag_) {
     sensor_msgs::MagneticField mag_msg;
     mag_msg.header = imu_msg.header;
     RosVector3FromVnVector3(mag_msg.magnetic_field, data.magnetic);
+    if (tf_ned_to_enu_) {
+        mag_msg.magnetic_field = WorldNEDtoENU(mag_msg.magnetic_field);
+    }
     pd_mag_.Publish(mag_msg);
   }
 
@@ -333,20 +468,47 @@ void RosQuaternionFromVnQuaternion(geometry_msgs::Quaternion& ros_quat,
   ros_quat.w = vn_quat.w;
 }
 
-void FillImuMessage(sensor_msgs::Imu& imu_msg,
-                    const VnDeviceCompositeData& data, bool binary_output) {
-  if (binary_output) {
-    RosQuaternionFromVnQuaternion(imu_msg.orientation, data.quaternion);
-    // NOTE: The IMU angular velocity and linear acceleration outputs are
-    // swapped. And also why are they different?
-    RosVector3FromVnVector3(imu_msg.angular_velocity,
-                            data.accelerationUncompensated);
-    RosVector3FromVnVector3(imu_msg.linear_acceleration,
-                            data.angularRateUncompensated);
-  } else {
-    RosVector3FromVnVector3(imu_msg.linear_acceleration, data.acceleration);
-    RosVector3FromVnVector3(imu_msg.angular_velocity, data.angularRate);
-  }
+geometry_msgs::Vector3 WorldNEDtoENU(const geometry_msgs::Vector3& ned) {
+  // (x y z) -> (y  x -z)
+  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L217
+  geometry_msgs::Vector3 enu;
+  enu.x = ned.y;
+  enu.y = ned.x;
+  enu.z = -ned.z;
+  return enu;
+}
+
+geometry_msgs::Quaternion WorldNEDtoENU(const geometry_msgs::Quaternion& ned) {
+  // (w x y z)->(y  x -z w)
+  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L217
+  geometry_msgs::Quaternion enu;
+  enu.x = ned.x;
+  enu.y = -ned.z;
+  enu.z = ned.w;
+  enu.w = ned.y;
+  return enu;
+}
+
+geometry_msgs::Vector3 BodyFixedNEDtoENU(const geometry_msgs::Vector3 ned) {
+  // (x y z)->(x -y -z)
+  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L216
+  geometry_msgs::Vector3 enu;
+  enu.x = ned.x;
+  enu.y -ned.y;
+  enu.z = -ned.z;
+  return enu;
+}
+
+geometry_msgs::Quaternion BodyFixedNEDtoENU(
+  const geometry_msgs::Quaternion& ned) {
+  // (w x y z)->(x -y -z w)
+  // https://github.com/ros-drivers/um7/blob/indigo-devel/src/main.cpp#L217
+  geometry_msgs::Quaternion enu;
+  enu.x = -ned.y;
+  enu.y = -ned.z;
+  enu.z = ned.w;
+  enu.w = ned.x;
+  return enu;
 }
 
 }  //  namespace imu_vn_100

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -388,6 +388,7 @@ void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
 
   if (enable_rpy_) {
     geometry_msgs:Vector3Stamped rpy_msg;
+    rpy_msg.header= imu_msg.header;
     rpy_msg.vector.z = data.ypr.yaw * M_PI/180.0;
     rpy_msg.vector.y = data.ypr.pitch * M_PI/180.0;
     rpy_msg.vector.x = data.ypr.roll * M_PI/180.0;


### PR DESCRIPTION
was converting from [um7](http://wiki.ros.org/um7) -> vn-100 and found these to help in migration:

- `imu/rpy` topic (default `off`)
- compensated imu data (default `uncompensated`)
- binary serial port selection (default `2`)
- ned -> enu tf (default `off`)
- add orientation qat to `imu/imu`
- expose vpe settings

tried to keep default behavior the same as current.