### PR TITLE
Using BINARY_ASYNC_MODE_SERIAL_1 to avoid permission denied.

### DIFF
--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -214,7 +214,7 @@ void ImuVn100::Stream(bool async) {
     if (binary_output_) {
       // Set the binary output data type and data rate
       VnEnsure(vn100_setBinaryOutput1Configuration(
-          &imu_, BINARY_ASYNC_MODE_SERIAL_2, kBaseImuRate / imu_rate_,
+          &imu_, BINARY_ASYNC_MODE_SERIAL_1, kBaseImuRate / imu_rate_,
           BG1_QTN | BG1_IMU | BG1_MAG_PRES | BG1_SYNC_IN_CNT,
           // BG1_IMU,
           BG3_NONE, BG5_NONE, true));


### PR DESCRIPTION
With default BINARY_ASYNC_MODE_SERIAL_2 the ROS node was not publishing data. Moreover with some combination of baudrate and imu_rate, the permission denied error was showing up.