### PR TITLE
Allow initial connection to the VN100 at other baud rates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,22 +14,32 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(Threads REQUIRED)
 
 include_directories(
   include
   vncpplib/include
 )
 
-add_library(imu_vn_100
+add_library(imu_vn_100_cpplib
   vncpplib/src/arch/linux/vncp_services.c
   vncpplib/src/vndevice.c
   vncpplib/src/vn100.c
+)
+target_link_libraries(imu_vn_100_cpplib
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_library(imu_vn_100
   src/imu_vn_100.cpp
 )
 ament_target_dependencies(imu_vn_100
   geometry_msgs
   rclcpp
   sensor_msgs
+)
+target_link_libraries(imu_vn_100
+  imu_vn_100_cpplib
 )
 
 add_executable(imu_vn_100_node
@@ -39,14 +49,22 @@ ament_target_dependencies(imu_vn_100_node
 )
 target_link_libraries(imu_vn_100_node
   imu_vn_100
+  imu_vn_100_cpplib
 )
 
-install(TARGETS imu_vn_100
+add_executable(imu_vn_100_flash_baud_rate
+  src/imu_vn_100_flash_baud_rate.cpp
+)
+target_link_libraries(imu_vn_100_flash_baud_rate
+  imu_vn_100_cpplib
+)
+
+install(TARGETS imu_vn_100 imu_vn_100_cpplib
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
-install(TARGETS imu_vn_100_node
+install(TARGETS imu_vn_100_node imu_vn_100_flash_baud_rate
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Port which the device connected to. This can be checked by command `dmesg`.
 
 The frame ID entry for the sent messages.
 
+`initial_baudrate` (`int`, `115200`)
+
+The baud rate to use to initially connect to the serial port.  Out of the box, the device will use 115200 (the default).  However, it is possible to change the default baud rate permanently on the device using the `imu_vn100_flash_baud_rate` utility.  For maximum reliability, this should be set to the same as the `baudrate` below (think about the case where the node crashes; it got set to the `baudrate` value, but if we try to reconnect at a different rate it will fail).
+
 `baudrate` (`int`, `921600`)
 
 The baud rate of the serial port. The available baud rates can be checked on the user manual. It is suggested that the baud rate is kept at `921600` to ensure the high frequency transmission. The device will send `permission denied` error code if the baud rate cannot support the desired data package at the desired frequency.

--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -83,8 +83,9 @@ class ImuVn100 final : public rclcpp::Node {
 
   // Settings
   std::string port_;
-  int baudrate_ = 921600;
-  int imu_rate_ = kDefaultImuRate;
+  uint32_t baudrate_;
+  uint32_t initial_baudrate_;
+  int imu_rate_;
   double imu_rate_double_ = kDefaultImuRate;
   std::string frame_id_;
 

--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -86,25 +86,23 @@ class ImuVn100 final : public rclcpp::Node {
   uint32_t baudrate_;
   uint32_t initial_baudrate_;
   int imu_rate_;
-  double imu_rate_double_ = kDefaultImuRate;
+  double imu_rate_double_;
   std::string frame_id_;
 
-  bool enable_mag_ = true;
-  bool enable_pres_ = true;
-  bool enable_temp_ = true;
-  bool enable_rpy_ = false;
+  bool enable_mag_;
+  bool enable_pres_;
+  bool enable_temp_;
+  bool enable_rpy_;
 
-  bool binary_output_ = true;
-  int binary_async_mode_ = BINARY_ASYNC_MODE_SERIAL_2;
+  bool binary_output_;
+  int binary_async_mode_;
 
-  bool imu_compensated_ = false;
+  bool imu_compensated_;
 
-  bool tf_ned_to_enu_ = false;
-
-  bool vpe_enable_ = true;
-  int vpe_heading_mode_ = 1;
-  int vpe_filtering_mode_ = 1;
-  int vpe_tuning_mode_ = 1;
+  bool vpe_enable_;
+  int vpe_heading_mode_;
+  int vpe_filtering_mode_;
+  int vpe_tuning_mode_;
   VnVector3 vpe_mag_base_tuning_;
   VnVector3 vpe_mag_adaptive_tuning_;
   VnVector3 vpe_mag_adaptive_filtering_;

--- a/src/imu_vn_100_flash_baud_rate.cpp
+++ b/src/imu_vn_100_flash_baud_rate.cpp
@@ -1,0 +1,84 @@
+#include <chrono>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "vn100.h"
+
+using VnErrorCode = VN_ERROR_CODE;
+
+static void VnEnsure(const VnErrorCode& error_code, const std::string & msg)
+{
+  if (error_code == VNERR_NO_ERROR) return;
+
+  switch (error_code) {
+    case VNERR_UNKNOWN_ERROR:
+      throw std::runtime_error("VN " + msg + ": Unknown error");
+    case VNERR_NOT_IMPLEMENTED:
+      throw std::runtime_error("VN " + msg + ": Not implemented");
+    case VNERR_TIMEOUT:
+      throw std::runtime_error("VN " + msg + ": Operation timed out");
+    case VNERR_SENSOR_INVALID_PARAMETER:
+      throw std::runtime_error("VN " + msg + ": Sensor invalid paramter");
+    case VNERR_INVALID_VALUE:
+      throw std::runtime_error("VN " + msg + ": Invalid value");
+    case VNERR_FILE_NOT_FOUND:
+      throw std::runtime_error("VN " + msg + ": File not found");
+    case VNERR_NOT_CONNECTED:
+      throw std::runtime_error("VN " + msg + ": not connected");
+    case VNERR_PERMISSION_DENIED:
+      throw std::runtime_error("VN " + msg + ": Permission denied");
+    default:
+      throw std::runtime_error("VN " + msg + ": Unhandled error type");
+  }
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc != 4) {
+    fprintf(stderr, "A utility to permanently flash a new baud rate to the VN100T\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: %s <port> <connect_baudrate> <baud_rate_to_set>\n", argv[0]);
+    return 1;
+  }
+
+  std::string port = std::string(argv[1]);
+  uint32_t initial_baudrate = std::stoul(argv[2]);
+  uint32_t baudrate = std::stoul(argv[3]);
+
+  Vn100 imu;
+
+  fprintf(stderr, "Connecting to device\n");
+  VnEnsure(vn100_connect(&imu, port.c_str(), initial_baudrate), "Connect");
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  fprintf(stderr, "Connected to device at %s\n", port.c_str());
+
+  uint32_t old_baudrate;
+  VnEnsure(vn100_getSerialBaudRate(&imu, &old_baudrate), "getSerialBaudRate");
+  fprintf(stderr, "Default serial baudrate: %u\n", old_baudrate);
+
+  if (old_baudrate != baudrate) {
+    fprintf(stderr, "Set serial baudrate to %u\n", baudrate);
+    VnEnsure(vn100_setSerialBaudRate(&imu, baudrate, true), "setSerialBaudRate");
+
+    fprintf(stderr, "Disconnecting from device\n");
+    vn100_disconnect(&imu);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    fprintf(stderr, "Reconnecting to device\n");
+    VnEnsure(vn100_connect(&imu, port.c_str(), baudrate), "Reconnect");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    fprintf(stderr, "Connected to device at %s\n", port.c_str());
+
+    fprintf(stderr, "Permanently writing baudrate to device\n");
+    VnEnsure(vn100_writeSettings(&imu, true), "writeSettings");
+  } else {
+    fprintf(stderr, "Baudrate already set at requested %u, skipping\n", baudrate);
+  }
+
+  fprintf(stderr, "Disconnecting from the device\n");
+  vn100_disconnect(&imu);
+
+  return 0;
+}


### PR DESCRIPTION
This PR allows the user of this node to connect to the VN100 at baud rates other than the default of 115200.  This allows the node to support users that have flashed their device with different initial baudrate.  It does this by adding another parameter, `initial_baudrate`.  Additionally, it adds a command-line utility that makes it easier for users to permanently change the baudrate on their device. 