### PR TITLE
Use the relative timestamp from the device.

### DIFF
--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -113,6 +113,10 @@ class ImuVn100 final : public rclcpp::Node {
 
   SyncInfo sync_info_;
 
+  uint64_t device_time_zero_;
+  rclcpp::Time ros_time_zero_;
+  bool has_time_zero_{false};
+
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pd_imu_;
   rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr pd_mag_;
   rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr pd_pres_;


### PR DESCRIPTION
This is a more accurate representation of when the data was
actually collected.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>