### PR TITLE
ROS 2 Dashing cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,4 +68,10 @@ install(TARGETS imu_vn_100_node imu_vn_100_flash_baud_rate
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY
+  config
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()

--- a/config/default-imu_vn_100-params.yaml
+++ b/config/default-imu_vn_100-params.yaml
@@ -1,0 +1,47 @@
+imu_vn_100:
+    ros__parameters:
+        port: /dev/ttyUSB0
+        frame_id: imu_link
+        imu_rate: 100
+        initial_baudrate: 115200
+        baudrate: 921600
+        enable_mag: true
+        enable_pres: true
+        enable_temp: true
+        enable_rpy: false
+        sync_rate: 20
+        sync_pulse_width_us: 1000
+        binary_output: true
+        binary_async_mode: 2
+        imu_compensated: false
+        vpe:
+            enable: true
+            heading_mode: 1
+            filtering_mode: 1
+            tuning_mode: 1
+            mag_tuning:
+                base_tuning:
+                    x: 4.0
+                    y: 4.0
+                    z: 4.0
+                adaptive_tuning:
+                    x: 5.0
+                    y: 5.0
+                    z: 5.0
+                adaptive_filtering:
+                    x: 5.5
+                    y: 5.5
+                    z: 5.5
+            accel_tuning:
+                base_tuning:
+                    x: 5.0
+                    y: 5.0
+                    z: 5.0
+                adaptive_tuning:
+                    x: 3.0
+                    y: 3.0
+                    z: 3.0
+                adaptive_filtering:
+                    x: 4.0
+                    y: 4.0
+                    z: 4.0

--- a/launch/imu_vn_100-launch.py
+++ b/launch/imu_vn_100-launch.py
@@ -1,0 +1,26 @@
+import os
+
+import ament_index_python.packages
+import launch
+import launch_ros.actions
+
+
+def generate_launch_description():
+    config_directory = os.path.join(
+        ament_index_python.packages.get_package_share_directory('imu_vn_100'),
+        'config')
+    params = os.path.join(config_directory, 'default-imu_vn_100-params.yaml')
+    imu_vn_100_node = launch_ros.actions.Node(package='imu_vn_100',
+                                              node_executable='imu_vn_100_node',
+                                              output='both',
+                                              parameters=[params])
+
+    return launch.LaunchDescription([imu_vn_100_node,
+
+                                     launch.actions.RegisterEventHandler(
+                                         event_handler=launch.event_handlers.OnProcessExit(
+                                             target_action=imu_vn_100_node,
+                                             on_exit=[launch.actions.EmitEvent(
+                                                 event=launch.events.Shutdown())],
+                                         )),
+                                     ])

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -175,14 +175,15 @@ void ImuVn100::CreatePublishers() {
 void ImuVn100::Initialize() {
   LoadParameters();
 
-  RCLCPP_DEBUG(get_logger(), "Connecting to device");
+  RCLCPP_INFO(get_logger(), "Connecting to device %s at baudrate %u", port_.c_str(), initial_baudrate_);
   VnEnsure(vn100_connect(&imu_, port_.c_str(), initial_baudrate_));
   rclcpp::sleep_for(std::chrono::milliseconds(500));
-  RCLCPP_INFO(get_logger(), "Connected to device at %s", port_.c_str());
 
   uint32_t old_baudrate;
   VnEnsure(vn100_getSerialBaudRate(&imu_, &old_baudrate));
-  RCLCPP_INFO(get_logger(), "Default serial baudrate: %u", old_baudrate);
+  // We don't know if we've successfully connected until an operation succeeds,
+  // so only print this once `getSerialBaudRate` has succeeded.
+  RCLCPP_INFO(get_logger(), "Connected to device %s at baudrate %u", port_.c_str(), old_baudrate);
 
   if (initial_baudrate_ != baudrate_) {
     RCLCPP_INFO(get_logger(), "Set serial baudrate to %u", baudrate_);

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -124,31 +124,31 @@ void ImuVn100::LoadParameters() {
 
   imu_compensated_ = declare_parameter("imu_compensated", false);
 
-  vpe_enable_ = declare_parameter("vpe/enable", true);
+  vpe_enable_ = declare_parameter("vpe.enable", true);
 
-  vpe_heading_mode_ = declare_parameter("vpe/heading_mode", 1);
-  vpe_filtering_mode_ = declare_parameter("vpe/filtering_mode", 1);
-  vpe_tuning_mode_ = declare_parameter("vpe/tuning_mode", 1);
+  vpe_heading_mode_ = declare_parameter("vpe.heading_mode", 1);
+  vpe_filtering_mode_ = declare_parameter("vpe.filtering_mode", 1);
+  vpe_tuning_mode_ = declare_parameter("vpe.tuning_mode", 1);
 
-  vpe_mag_base_tuning_.c0 = declare_parameter("vpe/mag_tuning/base_tuning/x", 4.0);
-  vpe_mag_base_tuning_.c1 = declare_parameter("vpe/mag_tuning/base_tuning/y", 4.0);
-  vpe_mag_base_tuning_.c2 = declare_parameter("vpe/mag_tuning/base_tuning/z", 4.0);
-  vpe_mag_adaptive_tuning_.c0 = declare_parameter("vpe/mag_tuning/adaptive_tuning/x", 5.0);
-  vpe_mag_adaptive_tuning_.c1 = declare_parameter("vpe/mag_tuning/adaptive_tuning/y", 5.0);
-  vpe_mag_adaptive_tuning_.c2 = declare_parameter("vpe/mag_tuning/adaptive_tuning/z", 5.0);
-  vpe_mag_adaptive_filtering_.c0 = declare_parameter("vpe/mag_tuning/adaptive_filtering/x", 5.5);
-  vpe_mag_adaptive_filtering_.c1 = declare_parameter("vpe/mag_tuning/adaptive_filtering/y", 5.5);
-  vpe_mag_adaptive_filtering_.c2 = declare_parameter("vpe/mag_tuning/adaptive_filtering/z", 5.5);
+  vpe_mag_base_tuning_.c0 = declare_parameter("vpe.mag_tuning.base_tuning.x", 4.0);
+  vpe_mag_base_tuning_.c1 = declare_parameter("vpe.mag_tuning.base_tuning.y", 4.0);
+  vpe_mag_base_tuning_.c2 = declare_parameter("vpe.mag_tuning.base_tuning.z", 4.0);
+  vpe_mag_adaptive_tuning_.c0 = declare_parameter("vpe.mag_tuning.adaptive_tuning.x", 5.0);
+  vpe_mag_adaptive_tuning_.c1 = declare_parameter("vpe.mag_tuning.adaptive_tuning.y", 5.0);
+  vpe_mag_adaptive_tuning_.c2 = declare_parameter("vpe.mag_tuning.adaptive_tuning.z", 5.0);
+  vpe_mag_adaptive_filtering_.c0 = declare_parameter("vpe.mag_tuning.adaptive_filtering.x", 5.5);
+  vpe_mag_adaptive_filtering_.c1 = declare_parameter("vpe.mag_tuning.adaptive_filtering.y", 5.5);
+  vpe_mag_adaptive_filtering_.c2 = declare_parameter("vpe.mag_tuning.adaptive_filtering.z", 5.5);
 
-  vpe_accel_base_tuning_.c0 = declare_parameter("vpe/accel_tuning/base_tuning/x", 5.0);
-  vpe_accel_base_tuning_.c1 = declare_parameter("vpe/accel_tuning/base_tuning/y", 5.0);
-  vpe_accel_base_tuning_.c2 = declare_parameter("vpe/accel_tuning/base_tuning/z", 5.0);
-  vpe_accel_adaptive_tuning_.c0 = declare_parameter("vpe/accel_tuning/adaptive_tuning/x", 3.0);
-  vpe_accel_adaptive_tuning_.c1 = declare_parameter("vpe/accel_tuning/adaptive_tuning/y", 3.0);
-  vpe_accel_adaptive_tuning_.c2 = declare_parameter("vpe/accel_tuning/adaptive_tuning/z", 3.0);
-  vpe_accel_adaptive_filtering_.c0 = declare_parameter("vpe/accel_tuning/adaptive_filtering/x", 4.0);
-  vpe_accel_adaptive_filtering_.c1 = declare_parameter("vpe/accel_tuning/adaptive_filtering/y", 4.0);
-  vpe_accel_adaptive_filtering_.c2 = declare_parameter("vpe/accel_tuning/adaptive_filtering/z", 4.0);
+  vpe_accel_base_tuning_.c0 = declare_parameter("vpe.accel_tuning.base_tuning.x", 5.0);
+  vpe_accel_base_tuning_.c1 = declare_parameter("vpe.accel_tuning.base_tuning.y", 5.0);
+  vpe_accel_base_tuning_.c2 = declare_parameter("vpe.accel_tuning.base_tuning.z", 5.0);
+  vpe_accel_adaptive_tuning_.c0 = declare_parameter("vpe.accel_tuning.adaptive_tuning.x", 3.0);
+  vpe_accel_adaptive_tuning_.c1 = declare_parameter("vpe.accel_tuning.adaptive_tuning.y", 3.0);
+  vpe_accel_adaptive_tuning_.c2 = declare_parameter("vpe.accel_tuning.adaptive_tuning.z", 3.0);
+  vpe_accel_adaptive_filtering_.c0 = declare_parameter("vpe.accel_tuning.adaptive_filtering.x", 4.0);
+  vpe_accel_adaptive_filtering_.c1 = declare_parameter("vpe.accel_tuning.adaptive_filtering.y", 4.0);
+  vpe_accel_adaptive_filtering_.c2 = declare_parameter("vpe.accel_tuning.adaptive_filtering.z", 4.0);
 
   FixImuRate();
   sync_info_.FixSyncRate();

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -514,23 +514,19 @@ void ImuVn100::VnEnsure(const VnErrorCode& error_code) {
     case VNERR_NOT_IMPLEMENTED:
       throw std::runtime_error("VN: Not implemented");
     case VNERR_TIMEOUT:
-      RCLCPP_WARN(get_logger(), "Operation timed out");
-      break;
+      throw std::runtime_error("VN: Operation timed out");
     case VNERR_SENSOR_INVALID_PARAMETER:
-      RCLCPP_WARN(get_logger(), "VN: Sensor invalid paramter");
-      break;
+      throw std::runtime_error("VN: Sensor invalid paramter");
     case VNERR_INVALID_VALUE:
-      RCLCPP_WARN(get_logger(), "VN: Invalid value");
-      break;
+      throw std::runtime_error("VN: Invalid value");
     case VNERR_FILE_NOT_FOUND:
-      RCLCPP_WARN(get_logger(), "VN: File not found");
-      break;
+      throw std::runtime_error("VN: File not found");
     case VNERR_NOT_CONNECTED:
       throw std::runtime_error("VN: not connected");
     case VNERR_PERMISSION_DENIED:
       throw std::runtime_error("VN: Permission denied");
     default:
-      RCLCPP_WARN(get_logger(), "Unhandled error type");
+      throw std::runtime_error("VN: Unhandled error type");
   }
 }
 

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -441,8 +441,8 @@ void ImuVn100::Disconnect() {
 
 void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
   if (!has_time_zero_) {
-    device_time_zero_ = data.timeStartup;
     ros_time_zero_ = this->now();
+    device_time_zero_ = data.timeStartup;
     has_time_zero_ = true;
   }
 


### PR DESCRIPTION
This PR does a few more cleanups on the ROS 2 Dashing port.  In particular:

1.  It has a bug fix to change `VnEnsure` to always throw an exception.  `VnEnsure` is only called during setup, and if any of the things during setup fail, we really want the node to fail.
1.  It clarifies the debug logging around "Connect" so it is clear when we are trying to connect and when we actually succeeded in connecting.
1.  It changes the separator character for the parameters from `/` to `.`.  This allows us to use a parameter hierarchy.
1.  It adds a default configuration file.
1.  It adds a default launch file.