### PR TITLE
Dashing: Changes to make ImuVn100 available as a component.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -21,7 +22,7 @@ include_directories(
   vncpplib/include
 )
 
-add_library(imu_vn_100_cpplib
+add_library(imu_vn_100_cpplib SHARED
   vncpplib/src/arch/linux/vncp_services.c
   vncpplib/src/vndevice.c
   vncpplib/src/vn100.c
@@ -30,17 +31,21 @@ target_link_libraries(imu_vn_100_cpplib
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-add_library(imu_vn_100
+add_library(imu_vn_100 SHARED
   src/imu_vn_100.cpp
 )
 ament_target_dependencies(imu_vn_100
   geometry_msgs
   rclcpp
+  rclcpp_components
   sensor_msgs
 )
 target_link_libraries(imu_vn_100
   imu_vn_100_cpplib
 )
+
+rclcpp_components_register_nodes(imu_vn_100
+  "imu_vn_100::ImuVn100")
 
 add_executable(imu_vn_100_node
   src/imu_vn_100_node.cpp)

--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -41,7 +41,7 @@ class ImuVn100 final : public rclcpp::Node {
   static constexpr int kDefaultImuRate = 100;
   static constexpr int kDefaultSyncOutRate = 20;
 
-  ImuVn100();
+  explicit ImuVn100(const rclcpp::NodeOptions& options);
   ImuVn100(const ImuVn100&) = delete;
   ImuVn100& operator=(const ImuVn100&) = delete;
   ~ImuVn100();

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
 
   <export>

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -28,6 +28,7 @@
 #include <geometry_msgs/msg/vector3.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/fluid_pressure.hpp>
@@ -82,10 +83,11 @@ void ImuVn100::SyncInfo::FixSyncRate() {
   }
 }
 
-ImuVn100::ImuVn100() : rclcpp::Node("imu_vn_100")
+ImuVn100::ImuVn100(const rclcpp::NodeOptions& options) : rclcpp::Node("imu_vn_100", options)
 {
   Initialize();
   imu_vn_100_ptr = this;
+  this->Stream(true);
 }
 
 ImuVn100::~ImuVn100() { Disconnect(); }
@@ -547,3 +549,5 @@ void RosQuaternionFromVnQuaternion(geometry_msgs::msg::Quaternion& ros_quat,
 }
 
 }  //  namespace imu_vn_100
+
+RCLCPP_COMPONENTS_REGISTER_NODE(imu_vn_100::ImuVn100)

--- a/src/imu_vn_100_node.cpp
+++ b/src/imu_vn_100_node.cpp
@@ -28,8 +28,7 @@ int main(int argc, char** argv) {
   // even from a launch file.
   setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
-  auto imu = std::make_shared<imu_vn_100::ImuVn100>();
-  imu->Stream(true);
+  auto imu = std::make_shared<imu_vn_100::ImuVn100>(rclcpp::NodeOptions());
 
   rclcpp::spin(imu);
 


### PR DESCRIPTION
With this it is possible to make ImuVn100 a component, similar
to a nodelet in ROS 1.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>