### PR TITLE
Dashing: Periodically resynchronize time.

### DIFF
--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -116,9 +116,15 @@ class ImuVn100 final : public rclcpp::Node {
 
   SyncInfo sync_info_;
 
-  uint64_t device_time_zero_;
+  rclcpp::Time last_cb_time_;
+  bool synchronize_timestamps_{true};
   rclcpp::Time ros_time_zero_;
-  bool has_time_zero_{false};
+  int64_t cb_delta_epsilon_ns_{0};
+  uint64_t data_time_zero_ns_{0};
+  bool can_publish_{false};
+  int64_t time_resync_interval_ns_{0};
+  int64_t data_interval_ns_{0};
+  uint64_t last_ros_stamp_ns_{0};
 
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pd_imu_;
   rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr pd_mag_;


### PR DESCRIPTION
We are currently using the device timestamps to determine the
"local" time that should be attached to the reading.  This
works for a while, but since the crystal on the IMU and the
crystal on the local machine are separate, they eventually
drift apart.  Fix this by periodically resynchronizing between
the local time and the device time.  There will always be
some difference between them, but with the algorithm implemented
here we know that that difference will be <= 1000/imu_rate (and
usually will be a lot less).

This should supersede #30 and fix #25 

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>