### PR TITLE
Publish both to imu/data and imu/data_raw.

### DIFF
--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -127,6 +127,7 @@ class ImuVn100 final : public rclcpp::Node {
   uint64_t last_ros_stamp_ns_{0};
 
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pd_imu_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pd_imu_raw_;
   rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr pd_mag_;
   rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr pd_pres_;
   rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr pd_temp_;

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -218,18 +218,19 @@ void ImuVn100::LoadParameters() {
 
 void ImuVn100::CreatePublishers() {
   imu_rate_double_ = imu_rate_;
-  pd_imu_ = this->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 10);
+  pd_imu_ = this->create_publisher<sensor_msgs::msg::Imu>("imu/data", 10);
+  pd_imu_raw_ = this->create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 10);
   if (enable_mag_) {
     pd_mag_ = this->create_publisher<sensor_msgs::msg::MagneticField>("imu/mag", 10);
   }
   if (enable_pres_) {
-    pd_pres_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("fluid_pressure", 10);
+    pd_pres_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("imu/fluid_pressure", 10);
   }
   if (enable_temp_) {
-    pd_temp_ = this->create_publisher<sensor_msgs::msg::Temperature>("temperature", 10);
+    pd_temp_ = this->create_publisher<sensor_msgs::msg::Temperature>("imu/temperature", 10);
   }
   if (enable_rpy_) {
-    pd_rpy_ = this->create_publisher<geometry_msgs::msg::Vector3Stamped>("rpy", 10);
+    pd_rpy_ = this->create_publisher<geometry_msgs::msg::Vector3Stamped>("imu/rpy", 10);
   }
 }
 
@@ -592,33 +593,59 @@ void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
 
     rclcpp::Time ros_time = rclcpp::Time(time_in_ns);
 
-    auto imu_msg = std::make_unique<sensor_msgs::msg::Imu>();
-    imu_msg->header.stamp = ros_time;
-    imu_msg->header.frame_id = frame_id_;
+    if (binary_output_) {
+      auto imu_msg = std::make_unique<sensor_msgs::msg::Imu>();
+      imu_msg->header.stamp = ros_time;
+      imu_msg->header.frame_id = frame_id_;
+
+      if (imu_compensated_) {
+        RosVector3FromVnVector3(imu_msg->linear_acceleration, data.acceleration);
+        RosVector3FromVnVector3(imu_msg->angular_velocity, data.angularRate);
+      } else {
+        // NOTE: The IMU angular velocity and linear acceleration outputs are
+        // swapped. And also why are they different?
+        RosVector3FromVnVector3(imu_msg->angular_velocity,
+                                data.accelerationUncompensated);
+        RosVector3FromVnVector3(imu_msg->linear_acceleration,
+                                data.angularRateUncompensated);
+      }
+      RosQuaternionFromVnQuaternion(imu_msg->orientation, data.quaternion);
+
+      imu_msg->angular_velocity_covariance[0] = angular_velocity_covariance_;
+      imu_msg->angular_velocity_covariance[4] = angular_velocity_covariance_;
+      imu_msg->angular_velocity_covariance[8] = angular_velocity_covariance_;
+
+      imu_msg->linear_acceleration_covariance[0] = linear_acceleration_covariance_;
+      imu_msg->linear_acceleration_covariance[4] = linear_acceleration_covariance_;
+      imu_msg->linear_acceleration_covariance[8] = linear_acceleration_covariance_;
+
+      pd_imu_->publish(std::move(imu_msg));
+    }
+
+    auto imu_raw_msg = std::make_unique<sensor_msgs::msg::Imu>();
+    imu_raw_msg->header.stamp = ros_time;
+    imu_raw_msg->header.frame_id = frame_id_;
 
     if (imu_compensated_) {
-      RosVector3FromVnVector3(imu_msg->linear_acceleration, data.acceleration);
-      RosVector3FromVnVector3(imu_msg->angular_velocity, data.angularRate);
+      RosVector3FromVnVector3(imu_raw_msg->linear_acceleration, data.acceleration);
+      RosVector3FromVnVector3(imu_raw_msg->angular_velocity, data.angularRate);
     } else {
       // NOTE: The IMU angular velocity and linear acceleration outputs are
       // swapped. And also why are they different?
-      RosVector3FromVnVector3(imu_msg->angular_velocity,
+      RosVector3FromVnVector3(imu_raw_msg->angular_velocity,
                               data.accelerationUncompensated);
-      RosVector3FromVnVector3(imu_msg->linear_acceleration,
+      RosVector3FromVnVector3(imu_raw_msg->linear_acceleration,
                               data.angularRateUncompensated);
     }
-    if (binary_output_) {
-      RosQuaternionFromVnQuaternion(imu_msg->orientation, data.quaternion);
-    }
-    imu_msg->angular_velocity_covariance[0] = angular_velocity_covariance_;
-    imu_msg->angular_velocity_covariance[4] = angular_velocity_covariance_;
-    imu_msg->angular_velocity_covariance[8] = angular_velocity_covariance_;
+    imu_raw_msg->angular_velocity_covariance[0] = angular_velocity_covariance_;
+    imu_raw_msg->angular_velocity_covariance[4] = angular_velocity_covariance_;
+    imu_raw_msg->angular_velocity_covariance[8] = angular_velocity_covariance_;
 
-    imu_msg->linear_acceleration_covariance[0] = linear_acceleration_covariance_;
-    imu_msg->linear_acceleration_covariance[4] = linear_acceleration_covariance_;
-    imu_msg->linear_acceleration_covariance[8] = linear_acceleration_covariance_;
+    imu_raw_msg->linear_acceleration_covariance[0] = linear_acceleration_covariance_;
+    imu_raw_msg->linear_acceleration_covariance[4] = linear_acceleration_covariance_;
+    imu_raw_msg->linear_acceleration_covariance[8] = linear_acceleration_covariance_;
 
-    pd_imu_->publish(std::move(imu_msg));
+    pd_imu_raw_->publish(std::move(imu_raw_msg));
 
     if (enable_rpy_) {
       auto rpy_msg = std::make_unique<geometry_msgs::msg::Vector3Stamped>();


### PR DESCRIPTION
This more closely resembles what REP 145 says, which is that
imu/data_raw should publish without an orientation estimate
while imu/data should publish *with* an orientation estimate.
It's actually cheap to do this, since if there are no subscribers
ROS 2 doesn't actually send any data on the wire.

While we are in here, change the prefix of the temperature,
fluid_pressure, and rpy to have "imu" so we are consistent.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a rebased version of https://github.com/KumarRobotics/imu_vn_100/pull/35 onto dashing-devel.  @ke-sun FYI.