### PR TITLE
Fixes pointed out by clang-tidy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,4 +79,8 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION include/${PROJECT_NAME}
+)
+
 ament_package()

--- a/include/imu_vn_100/imu_vn_100.hpp
+++ b/include/imu_vn_100/imu_vn_100.hpp
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef IMU_VN_100_ROS_H_
-#define IMU_VN_100_ROS_H_
+#ifndef IMU_VN_100_HPP_
+#define IMU_VN_100_HPP_
 
-#include <memory>
 #include <string>
 
 #include <geometry_msgs/msg/vector3_stamped.hpp>
@@ -44,19 +43,15 @@ class ImuVn100 final : public rclcpp::Node {
   explicit ImuVn100(const rclcpp::NodeOptions& options);
   ImuVn100(const ImuVn100&) = delete;
   ImuVn100& operator=(const ImuVn100&) = delete;
-  ~ImuVn100();
+  ~ImuVn100() override;
 
   void Initialize();
 
-  void Stream(bool async = true);
+  void Stream(bool async);
 
   void PublishData(const VnDeviceCompositeData& data);
 
   void RequestOnce();
-
-  void Idle(bool need_reply = true);
-
-  void Resume(bool need_reply = true);
 
   void Disconnect();
 
@@ -76,43 +71,41 @@ class ImuVn100 final : public rclcpp::Node {
     bool SyncEnabled() const;
   };
 
-  const SyncInfo sync_info() const { return sync_info_; }
-
  private:
-  Vn100 imu_;
+  Vn100 imu_{};
 
   // Settings
   std::string port_;
-  uint32_t baudrate_;
-  uint32_t initial_baudrate_;
-  int imu_rate_;
-  double imu_rate_double_;
+  uint32_t baudrate_{0};
+  uint32_t initial_baudrate_{0};
+  int imu_rate_{0};
+  double imu_rate_double_{0.0};
   std::string frame_id_;
 
-  double linear_acceleration_covariance_;
-  double angular_velocity_covariance_;
-  double magnetic_field_covariance_;
+  double linear_acceleration_covariance_{0.0};
+  double angular_velocity_covariance_{0.0};
+  double magnetic_field_covariance_{0.0};
 
-  bool enable_mag_;
-  bool enable_pres_;
-  bool enable_temp_;
-  bool enable_rpy_;
+  bool enable_mag_{false};
+  bool enable_pres_{false};
+  bool enable_temp_{false};
+  bool enable_rpy_{false};
 
-  bool binary_output_;
-  int binary_async_mode_;
+  bool binary_output_{false};
+  int binary_async_mode_{0};
 
-  bool imu_compensated_;
+  bool imu_compensated_{false};
 
-  bool vpe_enable_;
-  int vpe_heading_mode_;
-  int vpe_filtering_mode_;
-  int vpe_tuning_mode_;
-  VnVector3 vpe_mag_base_tuning_;
-  VnVector3 vpe_mag_adaptive_tuning_;
-  VnVector3 vpe_mag_adaptive_filtering_;
-  VnVector3 vpe_accel_base_tuning_;
-  VnVector3 vpe_accel_adaptive_tuning_;
-  VnVector3 vpe_accel_adaptive_filtering_;
+  bool vpe_enable_{false};
+  int vpe_heading_mode_{0};
+  int vpe_filtering_mode_{0};
+  int vpe_tuning_mode_{0};
+  VnVector3 vpe_mag_base_tuning_{};
+  VnVector3 vpe_mag_adaptive_tuning_{};
+  VnVector3 vpe_mag_adaptive_filtering_{};
+  VnVector3 vpe_accel_base_tuning_{};
+  VnVector3 vpe_accel_adaptive_tuning_{};
+  VnVector3 vpe_accel_adaptive_filtering_{};
 
   SyncInfo sync_info_;
 
@@ -139,9 +132,9 @@ class ImuVn100 final : public rclcpp::Node {
 
   // Just don't like type that is ALL CAP
   using VnErrorCode = VN_ERROR_CODE;
-  void VnEnsure(const VnErrorCode& error_code);
+  static void VnEnsure(const VnErrorCode& error_code);
 };
 
 }  // namespace imu_vn_100
 
-#endif  // IMU_VN_100_ROS_H_
+#endif  // IMU_VN_100_HPP_

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -22,7 +22,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <imu_vn_100/imu_vn_100.h>
+#include <imu_vn_100/imu_vn_100.hpp>
 
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
@@ -55,7 +55,9 @@ constexpr int ImuVn100::kDefaultSyncOutRate;
 
 void ImuVn100::SyncInfo::Update(const unsigned sync_count,
                                 const rclcpp::Time& sync_time) {
-  if (rate <= 0) return;
+  if (rate <= 0) {
+    return;
+  }
 
   if (count != sync_count) {
     count = sync_count;
@@ -73,7 +75,7 @@ void ImuVn100::SyncInfo::FixSyncRate() {
     }
     skip_count =
         (std::floor(ImuVn100::kBaseImuRate / static_cast<double>(rate) +
-                    0.5f)) -
+                    0.5)) -
         1;
 
     if (pulse_width_us > 10000) {
@@ -394,7 +396,7 @@ void ImuVn100::Stream(bool async) {
       std::list<std::string> sgrp1 = {"BG1_QTN", "BG1_SYNC_IN_CNT", "BG1_TIME_STARTUP"};
       if (enable_rpy_) {
         grp1 |= BG1_YPR;
-        sgrp1.push_back("BG1_YPR");
+        sgrp1.emplace_back("BG1_YPR");
       }
       uint16_t grp3 = BG3_NONE;
       std::list<std::string> sgrp3;
@@ -402,27 +404,27 @@ void ImuVn100::Stream(bool async) {
       std::list<std::string> sgrp5;
       if (imu_compensated_) {
         grp1 |=  BG1_ACCEL | BG1_ANGULAR_RATE;
-        sgrp1.push_back("BG1_ACCEL");
-        sgrp1.push_back("BG1_ANGULAR_RATE");
+        sgrp1.emplace_back("BG1_ACCEL");
+        sgrp1.emplace_back("BG1_ANGULAR_RATE");
         if (enable_mag_) {
           grp3 |= BG3_MAG;
-          sgrp3.push_back("BG3_MAG");
+          sgrp3.emplace_back("BG3_MAG");
         }
       } else {
         grp1 |=  BG1_IMU;
-        sgrp1.push_back("BG1_IMU");
+        sgrp1.emplace_back("BG1_IMU");
         if (enable_mag_) {
           grp3 |= BG3_UNCOMP_MAG;
-          sgrp3.push_back("BG3_UNCOMP_MAG");
+          sgrp3.emplace_back("BG3_UNCOMP_MAG");
         }
       }
       if (enable_temp_) {
           grp3 |= BG3_TEMP;
-          sgrp3.push_back("BG3_TEMP");
+          sgrp3.emplace_back("BG3_TEMP");
       }
       if (enable_pres_) {
           grp3 |= BG3_PRES;
-          sgrp3.push_back("BG3_PRES");
+          sgrp3.emplace_back("BG3_PRES");
       }
       if (!sgrp1.empty()) {
         std::stringstream ss;
@@ -485,14 +487,6 @@ void ImuVn100::Stream(bool async) {
 
   // Resume the device
   VnEnsure(vn100_resumeAsyncOutputs(&imu_, true));
-}
-
-void ImuVn100::Resume(bool need_reply) {
-  vn100_resumeAsyncOutputs(&imu_, need_reply);
-}
-
-void ImuVn100::Idle(bool need_reply) {
-  vn100_pauseAsyncOutputs(&imu_, need_reply);
 }
 
 void ImuVn100::Disconnect() {
@@ -710,7 +704,9 @@ void ImuVn100::PublishData(const VnDeviceCompositeData& data) {
 }
 
 void ImuVn100::VnEnsure(const VnErrorCode& error_code) {
-  if (error_code == VNERR_NO_ERROR) return;
+  if (error_code == VNERR_NO_ERROR) {
+    return;
+  }
 
   switch (error_code) {
     case VNERR_UNKNOWN_ERROR:

--- a/src/imu_vn_100_node.cpp
+++ b/src/imu_vn_100_node.cpp
@@ -17,9 +17,7 @@
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
-#include <imu_vn_100/imu_vn_100.h>
-
-using namespace imu_vn_100;
+#include <imu_vn_100/imu_vn_100.hpp>
 
 int main(int argc, char** argv) {
   rclcpp::init(argc, argv);

--- a/vncpplib/src/vndevice.c
+++ b/vncpplib/src/vndevice.c
@@ -2817,7 +2817,7 @@ void vndevice_processAsyncData(
 			return;
 		data.angularRateBias.c2 = atof(result);
 		result = strtok(0, delims);
-		if (result == NULL) {
+		if (result != NULL) {
       memcpy(sync_count, result+1, 10);
       data.syncInCnt = atoi(sync_count);
     }
@@ -2850,7 +2850,7 @@ void vndevice_processAsyncData(
 			return;
 		data.angularRateBiasVariance.c2 = atof(result);
 		result = strtok(0, delims);
-		if (result == NULL) {
+		if (result != NULL) {
       memcpy(sync_count, result+1, 10);
       data.syncInCnt = atoi(sync_count);
     }
@@ -3110,7 +3110,7 @@ void vndevice_processAsyncData(
 			return;
 		data.velU = (float) atof(result);
 		result = strtok(0, delims);
-		if (result == NULL) {
+		if (result != NULL) {
       memcpy(sync_count, result+1, 10);
       data.syncInCnt = atoi(sync_count);
     }


### PR DESCRIPTION
This is a bunch of small fixes seen by both code inspection and
pointed out by clang-tidy.

1.  Remove unused methods Resume and Idle
2.  Rename header file from .h to .hpp
3.  Install header files.
4.  Make sure to use emplace_back where possible.
5.  Fix a couple of small bugs in unlikely circumstances in
vndevice.c

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Tested with my VN100T rugged, and everything seems to work the same as before.