### PR TITLE
Update parameter name for Node launch action

### DIFF
--- a/launch/imu_vn_100-launch.py
+++ b/launch/imu_vn_100-launch.py
@@ -11,7 +11,7 @@ def generate_launch_description():
         'config')
     params = os.path.join(config_directory, 'default-imu_vn_100-params.yaml')
     imu_vn_100_node = launch_ros.actions.Node(package='imu_vn_100',
-                                              node_executable='imu_vn_100_node',
+                                              executable='imu_vn_100_node',
                                               output='both',
                                               parameters=[params])
 


### PR DESCRIPTION
`node_executable` was deprecated in Foxy in favour of `executable` (https://github.com/ros2/launch_ros/pull/140) and then removed in Galactic (https://github.com/ros2/launch_ros/pull/190).

This PR targets the `dashing` branch because that's the only ROS 2-related branch on this repo. If you create a `rolling` branch (i.e. a `master` branch for ROS 2) or a `galactic` branch (latest ROS 2 distro), then I can re-target the PR.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>